### PR TITLE
Use Vite's server.proxy to eliminate the need to hardcode the server's IP

### DIFF
--- a/{{cookiecutter.project_slug}}/.build/src/App.svelte
+++ b/{{cookiecutter.project_slug}}/.build/src/App.svelte
@@ -9,7 +9,7 @@
         window.location.href += 'default-client'
     }
 
-    const client = new StreamJamClient(`ws://localhost:7755/${client_id}`)
+    const client = new StreamJamClient(`${location.origin.replace(/^http/, 'ws')}/_sjsocket/${client_id}`)
     let client_connection = client.connect()
 
     setContext('streamjam', client)

--- a/{{cookiecutter.project_slug}}/.build/vite.config.js
+++ b/{{cookiecutter.project_slug}}/.build/vite.config.js
@@ -4,4 +4,12 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [svelte()],
+    server: {
+      proxy: {
+        "/_sjsocket": {
+          target: "ws://127.0.0.1:7755",
+          ws: true,
+        },
+      },
+    },
 })


### PR DESCRIPTION
By using [Vite's `server.proxy` feature](https://vitejs.dev/config/server-options#server-proxy), you wouldn't need to hardcode the server IP in the bundled code (as is currently necessary in https://github.com/creativesands/streamjam-examples/blob/main/click_monger/.build/src/App.svelte#L12)